### PR TITLE
fix(CLOUDDEV-594): fix client for working with l7policy

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,14 @@
 package edgecloud
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrMultipleResourcesWithTheSameName = errors.New("there are multiple resources with the same name")
+	ErrResourceDoesntExist              = errors.New("resource doesn't exist")
+)
 
 // ArgError is an error that represents an error with an input to edgecloud. It
 // identifies the argument and the cause (if possible).

--- a/l7policies.go
+++ b/l7policies.go
@@ -35,17 +35,19 @@ type L7Policy struct {
 	Region             string         `json:"region"`
 	ID                 string         `json:"id"`
 	TaskID             string         `json:"task_id"`
-	RedirectHTTPCode   int            `json:"redirect_http_code"`
+	RedirectHTTPCode   *int           `json:"redirect_http_code"`
 	Tags               []string       `json:"tags"`
 	ListenerID         string         `json:"listener_id"`
-	RedirectPoolID     string         `json:"redirect_pool_id"`
+	RedirectPoolID     *string        `json:"redirect_pool_id"`
 	OperatingStatus    string         `json:"operating_status"`
 	ProvisioningStatus string         `json:"provisioning_status"`
-	RedirectURL        string         `json:"redirect_url"`
+	RedirectURL        *string        `json:"redirect_url"`
 	Position           int            `json:"position"`
-	RedirectPrefix     string         `json:"redirect_prefix"`
+	RedirectPrefix     *string        `json:"redirect_prefix"`
 	Action             L7PolicyAction `json:"action"`
 	Rules              []L7Rule       `json:"rules"`
+	CreatedAt          string         `json:"created_at"`
+	UpdatedAt          string         `json:"updated_at,omitempty"`
 }
 
 type L7PolicyAction string
@@ -62,7 +64,7 @@ type L7PolicyCreateRequest struct {
 	RedirectHTTPCode int            `json:"redirect_http_code,omitempty"`
 	ListenerID       string         `json:"listener_id" required:"true" validate:"required"`
 	Position         int            `json:"position,omitempty"`
-	Name             string         `json:"name"`
+	Name             string         `json:"name,omitempty"`
 	Action           L7PolicyAction `json:"action" required:"true" validate:"required"`
 	RedirectURL      string         `json:"redirect_url,omitempty"`
 	RedirectPrefix   string         `json:"redirect_prefix,omitempty"`

--- a/util/l7policies.go
+++ b/util/l7policies.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	edgecloud "github.com/Edge-Center/edgecentercloud-go/v2"
 )
@@ -28,4 +29,29 @@ func L7PoliciesListByListenerID(ctx context.Context, client *edgecloud.Client, l
 	}
 
 	return L7Polices, nil
+}
+
+func GetLbL7PolicyFromName(ctx context.Context, client *edgecloud.Client, name string) (*edgecloud.L7Policy, error) {
+	allPolicies, _, err := client.L7Policies.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error from getting list of l7 policies: %w", err)
+	}
+	var resultPolicies []edgecloud.L7Policy
+	for _, policy := range allPolicies {
+		if policy.Name == name {
+			resultPolicies = append(resultPolicies, policy)
+		}
+	}
+
+	var l7Policy *edgecloud.L7Policy
+	switch len(resultPolicies) {
+	case 1:
+		l7Policy = &resultPolicies[0]
+	case 0:
+		return nil, fmt.Errorf("%w: resource \"l7policy\"; name \"%s\"", edgecloud.ErrResourceDoesntExist, name)
+	default:
+		return nil, fmt.Errorf("%w: resource \"l7policy\"; name \"%s\"", edgecloud.ErrMultipleResourcesWithTheSameName, name)
+	}
+
+	return l7Policy, nil
 }

--- a/util/l7policies_test.go
+++ b/util/l7policies_test.go
@@ -98,3 +98,33 @@ func TestL7PoliciesListByListenerID_ErrL7PoliciesNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrL7PoliciesNotFound)
 	assert.Nil(t, l7Policies)
 }
+
+func TestGetLbL7PolicyFromName_Ok(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	l7PolicyToFind := edgecloud.L7Policy{ID: testResourceID, Name: testName}
+	l7PolicyOther := edgecloud.L7Policy{ID: testResourceID2, Name: "other_name"}
+
+	l7Policies := []edgecloud.L7Policy{l7PolicyToFind, l7PolicyOther}
+	URL := path.Join("/v1/l7policies", strconv.Itoa(projectID), strconv.Itoa(regionID))
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(l7Policies)
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	l7Policy, err := GetLbL7PolicyFromName(context.Background(), client, testName)
+	assert.NoError(t, err)
+	assert.Equal(t, l7PolicyToFind, *l7Policy)
+}

--- a/util/resource_test.go
+++ b/util/resource_test.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	testResourceID = "f0d19cec-5c3f-4853-886e-304915960ff6"
-	testName       = "test-name"
-	projectID      = 2750
-	regionID       = 8
+	testResourceID  = "f0d19cec-5c3f-4853-886e-304915960ff6"
+	testResourceID2 = "40d19cec-5c3f-4853-886e-a6g6g3k95543"
+	testName        = "test-name"
+	projectID       = 2750
+	regionID        = 8
 )
 
 func TestResourceIsDeleted(t *testing.T) {


### PR DESCRIPTION
https://tracker.yandex.ru/CLOUDDEV-594

- Изменены типы атрибутов структур L7Policy и L7PolicyCreateRequest, для корректной передачи опциональных полей;
- Создана фукнция GetLbL7PolicyFromName для возможности получения l7 политики по имени;
- Написан 1 тест для функции GetLbL7PolicyFromName;
- Добавлены общие ошибки ErrMultipleResourcesWithTheSameName и ErrResourceDoesntExist для возможности их перехватывания.