### PR TITLE
feat(CLOUDDEV-857): add `SCHEDULED_FOR_DELETION` state and corresponding methods

### DIFF
--- a/projects_test.go
+++ b/projects_test.go
@@ -36,6 +36,61 @@ func TestProjects_Get(t *testing.T) {
 	require.Equal(t, respActual, expectedResp)
 }
 
+func TestProjects_ScheduleDeletion(t *testing.T) {
+	setup()
+	defer teardown()
+
+	scheduledForDeletionAt := "2024-08-06T17:40:32"
+	expectedResp := &Project{
+		ID:                     1,
+		Name:                   "project-scheduled-for-deletion",
+		State:                  ProjectStateScheduledForDeletion,
+		ScheduledForDeletionAt: &scheduledForDeletionAt,
+	}
+	URL := path.Join(projectsBasePath, "1", projectsScheduleDeletion)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		resp, err := json.Marshal(expectedResp)
+		if err != nil {
+			t.Errorf("failed to marshal response: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.Projects.ScheduleDeletion(ctx, "1")
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestProjects_CancelScheduledDeletion(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := &Project{
+		ID:                     1,
+		Name:                   "active-project",
+		State:                  ProjectStateActive,
+		ScheduledForDeletionAt: nil,
+	}
+	URL := path.Join(projectsBasePath, "1", projectsScheduleDeletion)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		resp, err := json.Marshal(expectedResp)
+		if err != nil {
+			t.Errorf("failed to marshal response: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.Projects.ScheduleDeletion(ctx, "1")
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
 func TestProjects_Delete(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
MR в рамках [CLOUDDEV-857](https://tracker.yandex.ru/CLOUDDEV-857)

# Изменения

- Добавлен новый статус `SCHEDULED_FOR_DELETION`
- Добавлено поле `ScheduledForDeletionAt` в сущность `Project` _(тут вопрос: правильный ли я выбрал тип `*string` для того, чтобы обозначить, что поле может быть `nil`?)_
- Реализованы методы `ScheduleDeletion`  и `CancelScheduledDeletion`, дёргающие соответствующие методы в Cloud API
- Написаны тесты для этих методов
