### PR TITLE
fix(CLOUDMKAAS-1066): make volume deletion idempotent on not found

### DIFF
--- a/util/resource.go
+++ b/util/resource.go
@@ -24,7 +24,7 @@ func ResourceIsDeleted[T any](ctx context.Context, getResourceFunc GetResourceFu
 		return errResourceNotDeleted
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil
 	}
 
@@ -33,6 +33,10 @@ func ResourceIsDeleted[T any](ctx context.Context, getResourceFunc GetResourceFu
 
 func ResourceIsExist[T any](ctx context.Context, getResourceFunc GetResourceFunc[T], id string) (bool, error) {
 	_, resp, err := getResourceFunc(ctx, id)
+
+	if resp == nil {
+		return false, fmt.Errorf("%w, details: %w", errGetResourceInfo, err)
+	}
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -48,10 +52,23 @@ func DeleteResourceIfExist(ctx context.Context, client *edgecloud.Client, resour
 	deleteAndWait := func(
 		deleter func(ctx context.Context, resourceID string) (*edgecloud.TaskResponse, *edgecloud.Response, error),
 	) error {
-		task, _, err := deleter(ctx, resourceID)
+		task, resp, err := deleter(ctx, resourceID)
 		if err != nil {
+			if IsNotFoundErr(resp) {
+				return nil
+			}
+
+			if IsLockedErr(resp) {
+				return RetryDeleteLocked(ctx, client, deleter, resourceID, timeouts...)
+			}
+
 			return err
 		}
+
+		if task == nil || len(task.Tasks) == 0 {
+			return nil
+		}
+
 		return WaitForTaskComplete(ctx, client, task.Tasks[0], timeouts...)
 	}
 
@@ -84,4 +101,57 @@ func DeleteResourceIfExist(ctx context.Context, client *edgecloud.Client, resour
 	default:
 		return errDeleteResourceIfExistIsNotSupported
 	}
+}
+
+func RetryDeleteLocked(ctx context.Context, client *edgecloud.Client,
+	deleter func(ctx context.Context, resourceID string) (*edgecloud.TaskResponse, *edgecloud.Response, error),
+	resourceID string,
+	timeouts ...time.Duration,
+) error {
+	timeout := defaultTimeout
+
+	if len(timeouts) > 0 {
+		timeout = timeouts[0]
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-ticker.C:
+			task, resp, err := deleter(ctx, resourceID)
+			if err != nil {
+				if IsNotFoundErr(resp) {
+					return nil
+				}
+
+				if IsLockedErr(resp) {
+					continue
+				}
+
+				return err
+			}
+
+			if task == nil || len(task.Tasks) == 0 {
+				return nil
+			}
+
+			return WaitForTaskComplete(ctx, client, task.Tasks[0], timeouts...)
+		}
+	}
+}
+
+func IsNotFoundErr(resp *edgecloud.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusNotFound
+}
+
+func IsLockedErr(resp *edgecloud.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusConflict
 }

--- a/util/task.go
+++ b/util/task.go
@@ -116,19 +116,19 @@ func WaitForTaskComplete(ctx context.Context, client *edgecloud.Client, taskID s
 		timeout = timeouts[0]
 	}
 
-	done := make(chan error)
-	go func() {
-		_, err := waitTask(ctx, client, taskID)
-		done <- err
-		close(done)
-	}()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
-	select {
-	case err := <-done:
+	_, err := waitTask(ctx, client, taskID)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return edgecloud.NewArgError("taskID", errTaskWaitTimeout.Error())
+		}
+
 		return err
-	case <-time.After(timeout):
-		return edgecloud.NewArgError("taskID", errTaskWaitTimeout.Error())
 	}
+
+	return nil
 }
 
 func WaitAndGetTaskInfo(ctx context.Context, client *edgecloud.Client, taskID string, timeouts ...time.Duration) (*edgecloud.Task, error) {


### PR DESCRIPTION
Описание

Исправлена логика удаления ресурсов и ожидания cloud task в edgecentercloud-go.

---

Изменения в DeleteResourceIfExist

Проблема

При удалении ресурса, который уже отсутствует в cloud, API возвращал 404 NotFound. Библиотека прокидывала эту ошибку выше, из-за чего вызывающий сервис продолжал ретраить удаление.

В случае CSI это приводило к бесконечным retry DeleteVolume и лишней нагрузке на cloud API.

Решение

* Добавлена обработка 404 NotFound как успешного результата удаления
* Добавлены helper-функции:

  * IsNotFoundErr
  * IsLockedErr
* Добавлена обработка 409 Conflict / locked через RetryDeleteLocked
* Добавлена защита от nil task и пустого списка task.Tasks

Результат

* DeleteResourceIfExist стал идемпотентным
* Повторное удаление уже отсутствующего ресурса больше не считается ошибкой
* Уменьшено количество лишних retry в сервисах, использующих библиотеку

---

Изменения в ResourceIsDeleted и ResourceIsExist

Проблема

В некоторых случаях response мог быть nil, что могло привести к panic при обращении к resp.StatusCode.

Решение

* Добавлена проверка resp != nil перед использованием StatusCode
* Для ResourceIsExist добавлена явная ошибка, если response не был получен

Результат

* Код стал устойчивее к ошибкам SDK/API
* Исключены потенциальные panic при нештатных ответах

---

Изменения в WaitForTaskComplete

Проблема

Ранее ожидание task выполнялось через отдельную goroutine и time.After. При timeout waitTask мог продолжать выполняться, что могло приводить к зависшим goroutine и некорректной отмене ожидания.

Решение

* Ожидание task переведено на context.WithTimeout
* waitTask теперь получает context с timeout
* context deadline преобразуется в ошибку timeout task

Результат

* Ожидание task корректно завершается по timeout
* Убрана потенциальная утечка goroutine
* Поведение ожидания task стало более предсказуемым

---

Итог

* Удаление ресурсов стало идемпотентным
* 404 NotFound при удалении больше не считается ошибкой
* 409 locked обрабатывается с контролируемым retry
* Ожидание task теперь ограничено context timeout
* Снижена вероятность бесконечных retry и лишней нагрузки на cloud API
