### PR TITLE
feat(TF-86)[DBaaS] add DBaaS API client support

### DIFF
--- a/dbaas.go
+++ b/dbaas.go
@@ -1,0 +1,535 @@
+package edgecloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	DBaaSClustersBasePathV3 = "/dbaas/v3/clusters"
+	DBaaSDbmsBasePathV3     = "/dbaas/v3/dbms"
+)
+
+type DBaaSService interface {
+	DBaaSClusters
+	DBaaSUsers
+	DBaaSDatabases
+	DBaaSDbmsService
+}
+
+type DBaaSClusters interface {
+	ClusterCreate(context.Context, DBaaSClusterCreateRequest) (*TaskResponse, *Response, error)
+	ClustersList(context.Context, *DBaaSClusterListOptions) ([]DBaaSCluster, *Response, error)
+	ClusterGet(context.Context, string) (*DBaaSCluster, *Response, error)
+	ClusterDelete(context.Context, string) (*TaskResponse, *Response, error)
+	ClusterUpdate(context.Context, string, DBaaSClusterUpdateRequest) (*TaskResponse, *Response, error)
+}
+
+type DBaaSUsers interface {
+	UsersList(ctx context.Context, clusterID string, opts *DBaaSUserListOptions) ([]DBaaSUser, *Response, error)
+	UserCreate(ctx context.Context, clusterID string, reqBody DBaaSUserCreateRequest) (*DBaaSUser, *Response, error)
+	UserGet(ctx context.Context, clusterID string, username string) (*DBaaSUser, *Response, error)
+	UserUpdate(ctx context.Context, clusterID string, username string, reqBody DBaaSUserUpdateRequest) (*Response, error)
+	UserDelete(ctx context.Context, clusterID string, username string) (*Response, error)
+	UserGrantAccess(ctx context.Context, clusterID string, username string, database string) (*Response, error)
+	UserRevokeAccess(ctx context.Context, clusterID string, username string, database string) (*Response, error)
+}
+
+type DBaaSDatabases interface {
+	DatabasesList(ctx context.Context, clusterID string, opts *DBaaSDatabaseListOptions) ([]DBaaSDatabase, *Response, error)
+	DatabaseCreate(ctx context.Context, clusterID string, reqBody DBaaSDatabaseCreateRequest) (*DBaaSDatabase, *Response, error)
+	DatabaseDelete(ctx context.Context, clusterID string, databaseName string) (*DBaaSDatabase, *Response, error)
+}
+
+type DBaaSDbmsService interface {
+	DbmsList(ctx context.Context, opts *DBaaSDbmsListOptions) ([]DBaaSDbms, *Response, error)
+}
+
+type DBaaSServiceOp struct {
+	client *Client
+}
+
+var _ DBaaSService = &DBaaSServiceOp{}
+
+type DBaaSCluster struct {
+	ID          string         `json:"id"`
+	ProjectID   int            `json:"project_id"`
+	RegionID    int            `json:"region_id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Status      string         `json:"status"`
+	DBMS        *DBaaSDbmsType `json:"dbms"`
+	CreatedAt   string         `json:"created_at"`
+	UpdatedAt   string         `json:"updated_at"`
+
+	// Get-specific (отсутствуют в List)
+	TaskID           string                 `json:"task_id,omitempty"`
+	CreatorTaskID    string                 `json:"creator_task_id,omitempty"`
+	HighAvailability bool                   `json:"high_availability,omitempty"`
+	Flavor           string                 `json:"flavor,omitempty"`
+	Volume           *DBaaSVolume           `json:"volume,omitempty"`
+	Interface        *DBaaSClusterInterface `json:"interface,omitempty"`
+	Connection       *DBaaSConnection       `json:"connection,omitempty"`
+}
+
+type DBaaSClusterCreateRequest struct {
+	Name             string                `json:"name"`
+	Description      string                `json:"description,omitempty"`
+	HighAvailability bool                  `json:"high_availability"`
+	DBMS             DBaaSDbmsType         `json:"dbms"`
+	Flavor           string                `json:"flavor"`
+	Volume           DBaaSVolume           `json:"volume"`
+	Interface        DBaaSClusterInterface `json:"interface"`
+}
+
+type DBaaSClusterUpdateRequest struct {
+	Name        string       `json:"name,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Flavor      string       `json:"flavor,omitempty"`
+	Volume      *DBaaSVolume `json:"volume,omitempty"`
+}
+
+type DBaaSDbmsType struct {
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+type DBaaSVolume struct {
+	Size int        `json:"size"`
+	Type VolumeType `json:"type"`
+}
+
+type DBaaSClusterInterface struct {
+	NetworkID string `json:"network_id"`
+	SubnetID  string `json:"subnet_id"`
+}
+
+type DBaaSClusterListOptions struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+type dbaasClustersRoot struct {
+	Count    int
+	Clusters []DBaaSCluster `json:"results"`
+}
+
+type DBaaSConnection struct {
+	Method string `json:"method"`
+	Host   string `json:"host"`
+	Port   int    `json:"port"`
+}
+
+type DBaaSUserListOptions struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+type dbaasUserRoot struct {
+	Count int
+	Users []DBaaSUser `json:"results"`
+}
+
+type DBaaSUserDatabase struct {
+	Name string `json:"name"`
+}
+
+type DBaaSUser struct {
+	Name      string              `json:"name"`
+	Databases []DBaaSUserDatabase `json:"databases"`
+}
+
+type DBaaSUserCreateRequest struct {
+	Name      string              `json:"name"`
+	Password  string              `json:"password"`
+	Databases []DBaaSUserDatabase `json:"databases,omitempty"`
+}
+
+type DBaaSUserUpdateRequest struct {
+	Password string `json:"password"`
+}
+
+type DBaaSDatabaseListOptions struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+type dbaasDatabaseRoot struct {
+	Count     int
+	Databases []DBaaSDatabase `json:"results"`
+}
+
+type DBaaSDatabase struct {
+	Name string `json:"name"`
+}
+
+type DBaaSDatabaseCreateRequest struct {
+	Name     string `json:"name"`
+	Encoding string `json:"encoding,omitempty"`
+	Locale   string `json:"locale,omitempty"`
+}
+
+type DBaaSDbmsListOptions struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+type dbaasDbmsRoot struct {
+	Count int
+	Dbms  []DBaaSDbms `json:"results"`
+}
+
+type DBaaSDbms struct {
+	ID      int    `json:"id"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+func (s *DBaaSServiceOp) ClusterCreate(ctx context.Context, reqBody DBaaSClusterCreateRequest) (*TaskResponse, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := s.client.addProjectRegionPath(DBaaSClustersBasePathV3)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := s.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
+}
+
+func (s *DBaaSServiceOp) ClustersList(ctx context.Context, opts *DBaaSClusterListOptions) ([]DBaaSCluster, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := s.client.addProjectRegionPath(DBaaSClustersBasePathV3)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dbaasClustersRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Clusters, resp, err
+}
+
+func (s *DBaaSServiceOp) ClusterGet(ctx context.Context, clusterID string) (*DBaaSCluster, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cluster := new(DBaaSCluster)
+	resp, err := s.client.Do(ctx, req, cluster)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return cluster, resp, err
+}
+
+func (s *DBaaSServiceOp) ClusterDelete(ctx context.Context, clusterID string) (*TaskResponse, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := s.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
+}
+
+func (s *DBaaSServiceOp) ClusterUpdate(ctx context.Context, clusterID string, reqBody DBaaSClusterUpdateRequest) (*TaskResponse, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := s.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
+}
+
+func (s *DBaaSServiceOp) UsersList(ctx context.Context, clusterID string, opts *DBaaSUserListOptions) ([]DBaaSUser, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dbaasUserRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Users, resp, err
+}
+
+func (s *DBaaSServiceOp) UserCreate(ctx context.Context, clusterID string, reqBody DBaaSUserCreateRequest) (*DBaaSUser, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user := new(DBaaSUser)
+	resp, err := s.client.Do(ctx, req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return user, resp, err
+}
+
+func (s *DBaaSServiceOp) UserGet(ctx context.Context, clusterID, username string) (*DBaaSUser, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID, username)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user := new(DBaaSUser)
+	resp, err := s.client.Do(ctx, req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return user, resp, err
+}
+
+func (s *DBaaSServiceOp) UserUpdate(ctx context.Context, clusterID, username string, reqBody DBaaSUserUpdateRequest) (*Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID, username)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+func (s *DBaaSServiceOp) UserDelete(ctx context.Context, clusterID, username string) (*Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID, username)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+func (s *DBaaSServiceOp) UserGrantAccess(ctx context.Context, clusterID, username, database string) (*Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users/%s/databases/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID, username, database)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+func (s *DBaaSServiceOp) UserRevokeAccess(ctx context.Context, clusterID, username, database string) (*Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/users/%s/databases/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID, username, database)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+func (s *DBaaSServiceOp) DatabasesList(ctx context.Context, clusterID string, opts *DBaaSDatabaseListOptions) ([]DBaaSDatabase, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/databases", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dbaasDatabaseRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Databases, resp, err
+}
+
+func (s *DBaaSServiceOp) DatabaseCreate(ctx context.Context, clusterID string, reqBody DBaaSDatabaseCreateRequest) (*DBaaSDatabase, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/databases", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	database := new(DBaaSDatabase)
+	resp, err := s.client.Do(ctx, req, database)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return database, resp, err
+}
+
+func (s *DBaaSServiceOp) DatabaseDelete(ctx context.Context, clusterID, databaseName string) (*DBaaSDatabase, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/databases/%s", s.client.addProjectRegionPath(DBaaSClustersBasePathV3), clusterID, databaseName)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	database := new(DBaaSDatabase)
+	resp, err := s.client.Do(ctx, req, database)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return database, resp, err
+}
+
+func (s *DBaaSServiceOp) DbmsList(ctx context.Context, opts *DBaaSDbmsListOptions) ([]DBaaSDbms, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := s.client.addProjectRegionPath(DBaaSDbmsBasePathV3)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dbaasDbmsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Dbms, resp, err
+}

--- a/dbaas_test.go
+++ b/dbaas_test.go
@@ -1,0 +1,429 @@
+package edgecloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	dbaasClusterName  = "my-db-cluster"
+	dbaasFlavor       = "db-g2-standard-2-4-30"
+	dbaasNetworkID    = "f0d19cec-5c3f-4853-886e-304915960ff4"
+	dbaasSubnetID     = "rtb19cec-5c3f-4853-886e-3045fk9g5kg9"
+	dbaasClusterID    = "123e4567-e89b-12d3-a456-426614174000"
+	dbaasUserName     = "user_name"
+	dbaasDatabaseName = "user_analytics"
+)
+
+func TestDBaaSServiceOp_ClusterCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := DBaaSClusterCreateRequest{
+		Name:             dbaasClusterName,
+		Description:      "Database Cluster",
+		HighAvailability: true,
+		DBMS: DBaaSDbmsType{
+			Type:    "POSTGRESQL",
+			Version: "17.5",
+		},
+		Flavor: dbaasFlavor,
+		Volume: DBaaSVolume{
+			Size: 30,
+			Type: "db_standard",
+		},
+		Interface: DBaaSClusterInterface{
+			NetworkID: dbaasNetworkID,
+			SubnetID:  dbaasSubnetID,
+		},
+	}
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		reqBody := &DBaaSClusterCreateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, err := json.Marshal(expectedResp)
+		if err != nil {
+			t.Errorf("failed to marshal response: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.ClusterCreate(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_ClustersList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := []DBaaSCluster{{ID: dbaasClusterID}}
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, err := json.Marshal(expectedResp)
+		if err != nil {
+			t.Errorf("failed to marshal response: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.ClustersList(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_ClusterGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := &DBaaSCluster{
+		ID:   dbaasClusterID,
+		Name: "my-db-cluster",
+	}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.ClusterGet(ctx, clusterID)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_ClusterDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.ClusterDelete(ctx, clusterID)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_ClusterUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := DBaaSClusterUpdateRequest{
+		Name: "updated-cluster",
+	}
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		reqBody := &DBaaSClusterUpdateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.ClusterUpdate(ctx, clusterID, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_UsersList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := []DBaaSUser{
+		{
+			Name: dbaasUserName,
+			Databases: []DBaaSUserDatabase{
+				{Name: dbaasDatabaseName},
+			},
+		},
+	}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users")
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.UsersList(ctx, clusterID, nil)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_UserCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := DBaaSUserCreateRequest{
+		Name:     dbaasUserName,
+		Password: "Qwerty!123456",
+		Databases: []DBaaSUserDatabase{
+			{Name: dbaasDatabaseName},
+		},
+	}
+	expectedResp := &DBaaSUser{
+		Name: dbaasUserName,
+		Databases: []DBaaSUserDatabase{
+			{Name: dbaasDatabaseName},
+		},
+	}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users")
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		reqBody := &DBaaSUserCreateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.UserCreate(ctx, clusterID, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_UserGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := &DBaaSUser{
+		Name: dbaasUserName,
+		Databases: []DBaaSUserDatabase{
+			{Name: dbaasDatabaseName},
+		},
+	}
+	clusterID := dbaasClusterID
+	username := dbaasUserName
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users", username)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.UserGet(ctx, clusterID, username)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_UserUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := DBaaSUserUpdateRequest{
+		Password: "Qwerty!123456",
+	}
+	clusterID := dbaasClusterID
+	username := dbaasUserName
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users", username)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		reqBody := &DBaaSUserUpdateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.DBaaS.UserUpdate(ctx, clusterID, username, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 204)
+}
+
+func TestDBaaSServiceOp_UserDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	clusterID := dbaasClusterID
+	username := dbaasUserName
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users", username)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.DBaaS.UserDelete(ctx, clusterID, username)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 204)
+}
+
+func TestDBaaSServiceOp_UserGrantAccess(t *testing.T) {
+	setup()
+	defer teardown()
+
+	clusterID := dbaasClusterID
+	username := dbaasUserName
+	database := dbaasDatabaseName
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users", username, "databases", database)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.DBaaS.UserGrantAccess(ctx, clusterID, username, database)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 204)
+}
+
+func TestDBaaSServiceOp_UserRevokeAccess(t *testing.T) {
+	setup()
+	defer teardown()
+
+	clusterID := dbaasClusterID
+	username := dbaasUserName
+	database := dbaasDatabaseName
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "users", username, "databases", database)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.DBaaS.UserRevokeAccess(ctx, clusterID, username, database)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 204)
+}
+
+func TestDBaaSServiceOp_DatabasesList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := []DBaaSDatabase{{Name: dbaasDatabaseName}}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "databases")
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.DatabasesList(ctx, clusterID, nil)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_DatabaseCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := DBaaSDatabaseCreateRequest{
+		Name:     "my-database",
+		Encoding: "UTF8",
+		Locale:   "en_US.utf8",
+	}
+	expectedResp := &DBaaSDatabase{Name: "my-database"}
+	clusterID := dbaasClusterID
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "databases")
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		reqBody := &DBaaSDatabaseCreateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.DatabaseCreate(ctx, clusterID, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_DatabaseDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := &DBaaSDatabase{Name: dbaasDatabaseName}
+	clusterID := dbaasClusterID
+	databaseName := dbaasDatabaseName
+	URL := path.Join(DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), clusterID, "databases", databaseName)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.DatabaseDelete(ctx, clusterID, databaseName)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_DbmsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := []DBaaSDbms{
+		{
+			ID:      1,
+			Type:    "POSTGRESQL",
+			Version: "17.5",
+		},
+	}
+	URL := path.Join(DBaaSDbmsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.DbmsList(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}

--- a/edgecloud.go
+++ b/edgecloud.go
@@ -80,6 +80,7 @@ type Client struct {
 	ResellerImageV2   ResellerImageV2Service
 	AvailabilityZones AvailabilityZonesService
 	MkaaS             MKaaSService
+	DBaaS             DBaaSService
 
 	// Optional function called after every successful request made to the DO APIs
 	onRequestCompleted RequestCompletionCallback
@@ -260,6 +261,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.ResellerImageV2 = &ResellerImageV2ServiceOp{client: c}
 	c.AvailabilityZones = &AvailabilityZonesServiceOp{client: c}
 	c.MkaaS = &MKaaSServiceOp{client: c}
+	c.DBaaS = &DBaaSServiceOp{client: c}
 
 	c.headers = make(map[string]string)
 

--- a/util/dbaas.go
+++ b/util/dbaas.go
@@ -1,0 +1,127 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	edgecloud "github.com/Edge-Center/edgecentercloud-go/v2"
+)
+
+const (
+	DBaaSClusterHealthyStatus = "HEALTHY"
+	dbaasClusterPollInterval  = 5 * time.Second
+)
+
+var (
+	ErrDBaaSClustersNotFound = errors.New("no DBaaS clusters were found for the specified search criteria")
+	ErrDBaaSClusterNotReady  = errors.New("DBaaS cluster failed to become healthy within the allocated time")
+)
+
+func CreateDBaaSClusterAndWait(ctx context.Context, client *edgecloud.Client, req edgecloud.DBaaSClusterCreateRequest, timeouts ...time.Duration) (*edgecloud.DBaaSCluster, error) {
+	task, _, err := client.DBaaS.ClusterCreate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if task == nil || len(task.Tasks) == 0 {
+		return nil, fmt.Errorf("DBaaS cluster create returned no task IDs")
+	}
+
+	cluster, err := WaitDBaaSClusterByCreatorTaskID(ctx, client, req.Name, task.Tasks[0], timeouts...)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err = WaitDBaaSClusterStatusHealthy(ctx, client, cluster.ID, timeouts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+func DBaaSClusterGetByCreatorTaskID(ctx context.Context, client *edgecloud.Client, name string, creatorTaskID string) (*edgecloud.DBaaSCluster, error) {
+	clusters, _, err := client.DBaaS.ClustersList(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range clusters {
+		if item.Name != name {
+			continue
+		}
+
+		cluster, _, err := client.DBaaS.ClusterGet(ctx, item.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		if cluster.CreatorTaskID == creatorTaskID {
+			return cluster, nil
+		}
+	}
+
+	return nil, ErrDBaaSClustersNotFound
+}
+
+func WaitDBaaSClusterByCreatorTaskID(ctx context.Context, client *edgecloud.Client, name string, creatorTaskID string, timeouts ...time.Duration) (*edgecloud.DBaaSCluster, error) {
+	timeout := defaultTimeout
+	if len(timeouts) > 0 {
+		timeout = timeouts[0]
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(dbaasClusterPollInterval)
+	defer ticker.Stop()
+
+	for {
+		cluster, err := DBaaSClusterGetByCreatorTaskID(ctx, client, name, creatorTaskID)
+		if err == nil {
+			return cluster, nil
+		}
+
+		if !errors.Is(err, ErrDBaaSClustersNotFound) {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, edgecloud.NewArgError("task error", errTaskWaitTimeout.Error())
+		case <-ticker.C:
+		}
+	}
+}
+
+func WaitDBaaSClusterStatusHealthy(ctx context.Context, client *edgecloud.Client, clusterID string, timeouts ...time.Duration) (*edgecloud.DBaaSCluster, error) {
+	timeout := defaultTimeout
+	if len(timeouts) > 0 {
+		timeout = timeouts[0]
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(dbaasClusterPollInterval)
+	defer ticker.Stop()
+
+	for {
+		cluster, _, err := client.DBaaS.ClusterGet(ctx, clusterID)
+		if err != nil {
+			return nil, err
+		}
+
+		if cluster.Status == DBaaSClusterHealthyStatus {
+			return cluster, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ErrDBaaSClusterNotReady
+		case <-ticker.C:
+		}
+	}
+}

--- a/util/dbaas_test.go
+++ b/util/dbaas_test.go
@@ -1,0 +1,293 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	edgecloud "github.com/Edge-Center/edgecentercloud-go/v2"
+)
+
+func TestDBaaSClusterGetByCreatorTaskID(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	clusters := []edgecloud.DBaaSCluster{
+		{ID: testResourceID, Name: testName},
+		{ID: testResourceID2, Name: testName},
+	}
+	listURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	getURLFirst := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID)
+	getURLSecond := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID2)
+
+	mux.HandleFunc(listURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(clusters)
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	mux.HandleFunc(getURLFirst, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSCluster{
+			ID:            testResourceID,
+			Name:          testName,
+			CreatorTaskID: testResourceID2,
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	mux.HandleFunc(getURLSecond, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSCluster{
+			ID:            testResourceID2,
+			Name:          testName,
+			CreatorTaskID: testResourceID,
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := DBaaSClusterGetByCreatorTaskID(context.Background(), client, testName, testResourceID)
+	assert.NoError(t, err)
+	assert.NotNil(t, cluster)
+	assert.Equal(t, testResourceID2, cluster.ID)
+}
+
+func TestDBaaSClusterGetByCreatorTaskID_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	clusters := []edgecloud.DBaaSCluster{{ID: testResourceID, Name: testName}}
+	listURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	getURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID)
+
+	mux.HandleFunc(listURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(clusters)
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSCluster{
+			ID:            testResourceID,
+			Name:          testName,
+			CreatorTaskID: testResourceID2,
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := DBaaSClusterGetByCreatorTaskID(context.Background(), client, testName, testResourceID)
+	assert.ErrorIs(t, err, ErrDBaaSClustersNotFound)
+	assert.Nil(t, cluster)
+}
+
+func TestWaitDBaaSClusterByCreatorTaskID_Timeout(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	listURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	mux.HandleFunc(listURL, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"results":[]}`)
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := WaitDBaaSClusterByCreatorTaskID(context.Background(), client, testName, testResourceID, time.Millisecond)
+	assert.Equal(t, edgecloud.NewArgError("task error", errTaskWaitTimeout.Error()), err)
+	assert.Nil(t, cluster)
+}
+
+func TestWaitDBaaSClusterStatusHealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	getURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID)
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSCluster{
+			ID:     testResourceID,
+			Status: DBaaSClusterHealthyStatus,
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := WaitDBaaSClusterStatusHealthy(context.Background(), client, testResourceID)
+	assert.NoError(t, err)
+	assert.NotNil(t, cluster)
+	assert.Equal(t, testResourceID, cluster.ID)
+}
+
+func TestWaitDBaaSClusterStatusHealthy_NotReady(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	getURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID)
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSCluster{
+			ID:     testResourceID,
+			Status: "PENDING_CREATE",
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := WaitDBaaSClusterStatusHealthy(context.Background(), client, testResourceID, 20*time.Millisecond)
+	assert.ErrorIs(t, err, ErrDBaaSClusterNotReady)
+	assert.Nil(t, cluster)
+}
+
+func TestCreateDBaaSClusterAndWait(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	reqBody := edgecloud.DBaaSClusterCreateRequest{
+		Name: testName,
+		DBMS: edgecloud.DBaaSDbmsType{
+			Type:    "POSTGRESQL",
+			Version: "17.5",
+		},
+		Flavor: "db-g2-standard-2-4-30",
+		Volume: edgecloud.DBaaSVolume{
+			Size: 30,
+			Type: "db_standard",
+		},
+		Interface: edgecloud.DBaaSClusterInterface{
+			NetworkID: testResourceID,
+			SubnetID:  testResourceID2,
+		},
+	}
+
+	createURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	getURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID)
+
+	mux.HandleFunc(createURL, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			got := &edgecloud.DBaaSClusterCreateRequest{}
+			if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			assert.Equal(t, reqBody, *got)
+
+			resp, err := json.Marshal(&edgecloud.TaskResponse{Tasks: []string{testResourceID2}})
+			if err != nil {
+				t.Fatalf("failed to marshal JSON: %v", err)
+			}
+			_, _ = fmt.Fprint(w, string(resp))
+
+			return
+		}
+
+		resp, err := json.Marshal([]edgecloud.DBaaSCluster{{ID: testResourceID, Name: testName}})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSCluster{
+			ID:            testResourceID,
+			Name:          testName,
+			CreatorTaskID: testResourceID2,
+			Status:        DBaaSClusterHealthyStatus,
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := CreateDBaaSClusterAndWait(context.Background(), client, reqBody)
+	assert.NoError(t, err)
+	assert.NotNil(t, cluster)
+	assert.Equal(t, testResourceID, cluster.ID)
+	assert.Equal(t, DBaaSClusterHealthyStatus, cluster.Status)
+}
+
+func TestCreateDBaaSClusterAndWait_EmptyTaskIDs(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	createURL := path.Join(edgecloud.DBaaSClustersBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	mux.HandleFunc(createURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.TaskResponse{})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	cluster, err := CreateDBaaSClusterAndWait(context.Background(), client, edgecloud.DBaaSClusterCreateRequest{Name: testName})
+	assert.EqualError(t, err, "DBaaS cluster create returned no task IDs")
+	assert.Nil(t, cluster)
+}

--- a/util/task.go
+++ b/util/task.go
@@ -48,6 +48,7 @@ type TaskResult struct {
 	Volumes        []string  `json:"volumes"`
 	MkaasClusters  []float64 `json:"mkaasclusters"`
 	MkaasPools     []float64 `json:"mkaaspools"`
+	DbaasClusters  []string  `json:"dbaasclusters"`
 }
 
 type TaskAPIFunc[T any] func(ctx context.Context, opt T) (*edgecloud.TaskResponse, *edgecloud.Response, error)


### PR DESCRIPTION
Add DBaaS (Database as a Service) API client implementation:

- Clusters CRUD (Create, List, Get, Update, Delete)
- Users CRUD (Create, List, Get, Update, Delete) + Grant/Revoke access
- Databases CRUD (Create, List, Delete)
- DBMS list (available database engines)

APIs are under /dbaas/v3/ paths. Implemented as a new service on the
existing client, following the same pattern as MKaaS.