### PR TITLE
feat(TF-103) [loadbalancers] add ChangeFlavor method for loadbalancers

### DIFF
--- a/loadbalancers.go
+++ b/loadbalancers.go
@@ -17,6 +17,7 @@ const (
 )
 
 const (
+	loadbalancersChangeFlavor  = "change_flavor"
 	loadbalancersCheckLimits   = "check_limits"
 	loadbalancersMetrics       = "metrics"
 	loadbalancersMember        = "member"
@@ -34,6 +35,7 @@ type LoadbalancersService interface {
 	Rename(context.Context, string, *Name) (*Loadbalancer, *Response, error)
 	MetricsList(context.Context, string, *LoadbalancerMetricsListRequest) ([]LoadbalancerMetrics, *Response, error)
 	FlavorList(context.Context, *FlavorsOptions) ([]Flavor, *Response, error)
+	ChangeFlavor(context.Context, string, *LoadbalancerChangeFlavorRequest) (*TaskResponse, *Response, error)
 
 	LoadbalancerListeners
 	LoadbalancerPools
@@ -225,6 +227,10 @@ type LoadbalancerCreateRequest struct {
 	Metadata     Metadata                            `json:"metadata,omitempty" validate:"omitempty,dive"`
 	Tags         []string                            `json:"tag,omitempty"`
 	FloatingIP   *InterfaceFloatingIP                `json:"floating_ip,omitempty" validate:"omitempty,dive"`
+}
+
+type LoadbalancerChangeFlavorRequest struct {
+	Flavor string `json:"flavor" required:"true"`
 }
 
 type LoadbalancerAlgorithm string
@@ -1074,6 +1080,36 @@ func (s *LoadbalancersServiceOp) MetricsList(ctx context.Context, loadbalancerID
 	}
 
 	return root.LoadbalancerMetrics, resp, err
+}
+
+// ChangeFlavor a load balancer flavor.
+func (s *LoadbalancersServiceOp) ChangeFlavor(ctx context.Context, loadbalancerID string, reqBody *LoadbalancerChangeFlavorRequest) (*TaskResponse, *Response, error) {
+	if resp, err := isValidUUID(loadbalancerID, "loadbalancerID"); err != nil {
+		return nil, resp, err
+	}
+
+	if reqBody == nil {
+		return nil, nil, NewArgError("reqBody", "cannot be nil")
+	}
+
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s/%s", s.client.addProjectRegionPath(loadbalancersBasePathV1), loadbalancerID, loadbalancersChangeFlavor)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := s.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
 }
 
 // FlavorList get load balancer flavors.

--- a/loadbalancers_test.go
+++ b/loadbalancers_test.go
@@ -152,6 +152,65 @@ func TestLoadbalancers_Create_reqBodyNil(t *testing.T) {
 	assert.EqualError(t, err, NewArgError("reqBody", "cannot be nil").Error())
 }
 
+func TestLoadbalancers_ChangeFlavor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := &LoadbalancerChangeFlavorRequest{
+		Flavor: "lb1-2-4",
+	}
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	URL := path.Join(loadbalancersBasePathV1, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID, loadbalancersChangeFlavor)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		reqBody := new(LoadbalancerChangeFlavorRequest)
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, reqBody)
+		resp, err := json.Marshal(expectedResp)
+		if err != nil {
+			t.Errorf("failed to marshal response: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.Loadbalancers.ChangeFlavor(ctx, testResourceID, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestLoadbalancers_ChangeFlavor_ResponseError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := &LoadbalancerChangeFlavorRequest{Flavor: "lb1-2-4"}
+	URL := path.Join(loadbalancersBasePathV1, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID, loadbalancersChangeFlavor)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, "Bad request")
+	})
+
+	respActual, resp, err := client.Loadbalancers.ChangeFlavor(ctx, testResourceID, request)
+	assert.Nil(t, respActual)
+	assert.Error(t, err)
+	assert.Equal(t, resp.StatusCode, 400)
+}
+
+func TestLoadbalancers_ChangeFlavor_reqBodyNil(t *testing.T) {
+	setup()
+	defer teardown()
+
+	respActual, resp, err := client.Loadbalancers.ChangeFlavor(ctx, testResourceID, nil)
+	assert.Nil(t, respActual)
+	assert.Nil(t, resp)
+	assert.EqualError(t, err, NewArgError("reqBody", "cannot be nil").Error())
+}
+
 func TestLoadbalancers_Delete(t *testing.T) {
 	setup()
 	defer teardown()
@@ -1407,6 +1466,16 @@ func TestLoadbalancers_Metadata_isValidUUID_Error_Return_Response(t *testing.T) 
 			require.EqualError(t, err, NewArgError("loadbalancerID", NotCorrectUUID).Error())
 		})
 	}
+}
+
+func TestLoadbalancers_ChangeFlavor_isValidUUID_Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	respActual, resp, err := client.Loadbalancers.ChangeFlavor(ctx, testResourceIDNotValidUUID, nil)
+	require.Nil(t, respActual)
+	require.Equal(t, 400, resp.StatusCode)
+	require.EqualError(t, err, NewArgError("loadbalancerID", NotCorrectUUID).Error())
 }
 
 func TestLoadbalancers_MetadataList_isValidUUID_Error(t *testing.T) {


### PR DESCRIPTION
feat(TF-103): add ChangeFlavor method for loadbalancers

Add support for `POST /v1/loadbalancers/{project_id}/{region_id}/{loadbalancer_id}/change_flavor`.

Changes:
- New `LoadbalancerChangeFlavorRequest` type
- `ChangeFlavor` method in `LoadbalancersService` interface
- Implementation on `LoadbalancersServiceOp`
- Unit tests (success / error / nil body / invalid UUID)