### PR TITLE
feat(TF-117) [mkaas] add VersionsList method for Kubernetes versions

### DIFF
--- a/mkaas.go
+++ b/mkaas.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	MKaaSClustersBasePathV2 = "/mkaas/v2/clusters"
+	MKaaSRegionsBasePathV2  = "/mkaas/v2/regions"
 	MKaaSBasePathV2         = "/mkaas/v2"
 )
 
@@ -17,7 +18,15 @@ type MKaaSService interface {
 	MKaaSClusters
 	MKaaSPools
 	MKaaSNodes
+	MKaaSRegions
 	MKaaSFlavors
+}
+
+type MKaaSRegions interface {
+	VersionsList(
+		ctx context.Context,
+		regionID int,
+	) (*MKaaSKubernetesVersionsResult, *Response, error)
 }
 
 type MKaaSFlavors interface {
@@ -91,6 +100,15 @@ type MKaaSServiceOp struct {
 }
 
 var _ MKaaSService = &MKaaSServiceOp{}
+
+type MKaaSKubernetesVersion struct {
+	Version  string `json:"version"`
+	IsLatest bool   `json:"is_latest"`
+}
+
+type MKaaSKubernetesVersionsResult struct {
+	Versions []MKaaSKubernetesVersion `json:"versions"`
+}
 
 type MKaaSClustersRoot struct {
 	Count    int
@@ -785,4 +803,27 @@ func (m *MKaaSServiceOp) FlavorsList(
 	}
 
 	return flavors, resp, nil
+}
+
+func (m *MKaaSServiceOp) VersionsList(
+	ctx context.Context,
+	regionID int,
+) (*MKaaSKubernetesVersionsResult, *Response, error) {
+	if resp, err := m.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	reqURL := fmt.Sprintf("%s/%d/versions", MKaaSRegionsBasePathV2, regionID)
+	req, err := m.client.NewRequest(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	versions := new(MKaaSKubernetesVersionsResult)
+	resp, err := m.client.Do(ctx, req, versions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return versions, resp, nil
 }

--- a/mkaas_test.go
+++ b/mkaas_test.go
@@ -135,6 +135,40 @@ func TestMKaaSServiceOp_ClustersGet(t *testing.T) {
 	require.Equal(t, respActual, expectedResp)
 }
 
+func TestMKaaSServiceOp_VersionsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const requestedRegionID = 42
+	expectedURL := fmt.Sprintf("%s/%d/versions", MKaaSRegionsBasePathV2, requestedRegionID)
+	expectedResp := &MKaaSKubernetesVersionsResult{
+		Versions: []MKaaSKubernetesVersion{
+			{Version: "v1.31.0", IsLatest: true},
+			{Version: "v1.32.13", IsLatest: false},
+			{Version: "v1.33.10", IsLatest: false},
+			{Version: "v1.34.8", IsLatest: true},
+		},
+	}
+
+	mux.HandleFunc(expectedURL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		require.Equal(t, expectedURL, r.URL.Path)
+		_, _ = fmt.Fprint(w, `{
+			"versions": [
+				{"is_latest": true, "version": "v1.31.0"},
+				{"is_latest": false, "version": "v1.32.13"},
+				{"is_latest": false, "version": "v1.33.10"},
+				{"is_latest": true, "version": "v1.34.8"}
+			]
+		}`)
+	})
+
+	actual, resp, err := client.MkaaS.VersionsList(ctx, requestedRegionID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, expectedResp, actual)
+}
+
 func TestMKaaSServiceOp_ClustersDelete(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds support for retrieving available Kubernetes versions for an MKaaS region via `GET /mkaas/v2/regions/{region_id}/versions`.

Includes response types, the `VersionsList` method, and unit tests.