### PR TITLE
feat(TF-114) [dbaas] add DBaaS backups API support

### DIFF
--- a/dbaas.go
+++ b/dbaas.go
@@ -9,12 +9,14 @@ import (
 const (
 	DBaaSClustersBasePathV3 = "/dbaas/v3/clusters"
 	DBaaSDbmsBasePathV3     = "/dbaas/v3/dbms"
+	DBaaSBackupsBasePathV3  = "/dbaas/v3/backups"
 )
 
 type DBaaSService interface {
 	DBaaSClusters
 	DBaaSUsers
 	DBaaSDatabases
+	DBaaSBackups
 	DBaaSDbmsService
 }
 
@@ -40,6 +42,15 @@ type DBaaSDatabases interface {
 	DatabasesList(ctx context.Context, clusterID string, opts *DBaaSDatabaseListOptions) ([]DBaaSDatabase, *Response, error)
 	DatabaseCreate(ctx context.Context, clusterID string, reqBody DBaaSDatabaseCreateRequest) (*DBaaSDatabase, *Response, error)
 	DatabaseDelete(ctx context.Context, clusterID string, databaseName string) (*DBaaSDatabase, *Response, error)
+}
+
+type DBaaSBackups interface {
+	BackupCreate(ctx context.Context, reqBody DBaaSBackupCreateRequest) (*TaskResponse, *Response, error)
+	BackupsList(ctx context.Context, opts *DBaaSBackupListOptions) ([]DBaaSBackup, *Response, error)
+	BackupsListPage(ctx context.Context, opts *DBaaSBackupListOptions) (*DBaaSBackupsPage, *Response, error)
+	BackupGet(ctx context.Context, backupID string, includePrices bool) (*DBaaSBackup, *Response, error)
+	BackupUpdate(ctx context.Context, backupID string, reqBody DBaaSBackupUpdateRequest) (*DBaaSBackup, *Response, error)
+	BackupDelete(ctx context.Context, backupID string) (*TaskResponse, *Response, error)
 }
 
 type DBaaSDbmsService interface {
@@ -184,6 +195,55 @@ type DBaaSDbms struct {
 	ID      int    `json:"id"`
 	Type    string `json:"type"`
 	Version string `json:"version"`
+}
+
+type DBaaSBackup struct {
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Description   string         `json:"description"`
+	BackupType    string         `json:"backup_type"`
+	ClusterID     string         `json:"cluster_id"`
+	ParentID      string         `json:"parent_id"`
+	Status        string         `json:"status"`
+	Size          float64        `json:"size"`
+	IsService     bool           `json:"is_service"`
+	HasChild      bool           `json:"has_child,omitempty"`
+	DBMS          *DBaaSDbmsType `json:"dbms"`
+	CreatedAt     string         `json:"created_at"`
+	UpdatedAt     string         `json:"updated_at"`
+	FinishedAt    string         `json:"finished_at"`
+	TaskID        string         `json:"task_id"`
+	CreatorTaskID string         `json:"creator_task_id"`
+}
+
+type DBaaSBackupCreateRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	ClusterID   string `json:"cluster_id"`
+	ParentID    string `json:"parent_id,omitempty"`
+}
+
+type DBaaSBackupUpdateRequest struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+type DBaaSBackupListOptions struct {
+	ClusterID     string `url:"cluster_id,omitempty"`
+	BackupType    string `url:"backup_type,omitempty"`
+	IsService     *bool  `url:"is_service,omitempty"`
+	CreatedFrom   string `url:"created_from,omitempty"`
+	CreatedTo     string `url:"created_to,omitempty"`
+	DbmsID        int    `url:"dbms_id,omitempty"`
+	Search        string `url:"search,omitempty"`
+	IncludePrices bool   `url:"include_prices,omitempty"`
+	Limit         int    `url:"limit,omitempty"`
+	Offset        int    `url:"offset,omitempty"`
+}
+
+type DBaaSBackupsPage struct {
+	Count   int           `json:"count"`
+	Results []DBaaSBackup `json:"results"`
 }
 
 func (s *DBaaSServiceOp) ClusterCreate(ctx context.Context, reqBody DBaaSClusterCreateRequest) (*TaskResponse, *Response, error) {
@@ -532,4 +592,125 @@ func (s *DBaaSServiceOp) DbmsList(ctx context.Context, opts *DBaaSDbmsListOption
 	}
 
 	return root.Dbms, resp, err
+}
+
+func (s *DBaaSServiceOp) BackupCreate(ctx context.Context, reqBody DBaaSBackupCreateRequest) (*TaskResponse, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := s.client.addProjectRegionPath(DBaaSBackupsBasePathV3)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := s.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
+}
+
+func (s *DBaaSServiceOp) BackupsList(ctx context.Context, opts *DBaaSBackupListOptions) ([]DBaaSBackup, *Response, error) {
+	page, resp, err := s.BackupsListPage(ctx, opts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return page.Results, resp, nil
+}
+
+func (s *DBaaSServiceOp) BackupsListPage(ctx context.Context, opts *DBaaSBackupListOptions) (*DBaaSBackupsPage, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := s.client.addProjectRegionPath(DBaaSBackupsBasePathV3)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page := new(DBaaSBackupsPage)
+	resp, err := s.client.Do(ctx, req, page)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return page, resp, nil
+}
+
+func (s *DBaaSServiceOp) BackupGet(ctx context.Context, backupID string, includePrices bool) (*DBaaSBackup, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s", s.client.addProjectRegionPath(DBaaSBackupsBasePathV3), backupID)
+	if includePrices {
+		path += "?include_prices=true"
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	backup := new(DBaaSBackup)
+	resp, err := s.client.Do(ctx, req, backup)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return backup, resp, err
+}
+
+func (s *DBaaSServiceOp) BackupUpdate(ctx context.Context, backupID string, reqBody DBaaSBackupUpdateRequest) (*DBaaSBackup, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s", s.client.addProjectRegionPath(DBaaSBackupsBasePathV3), backupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	backup := new(DBaaSBackup)
+	resp, err := s.client.Do(ctx, req, backup)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return backup, resp, err
+}
+
+func (s *DBaaSServiceOp) BackupDelete(ctx context.Context, backupID string) (*TaskResponse, *Response, error) {
+	if resp, err := s.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%s", s.client.addProjectRegionPath(DBaaSBackupsBasePathV3), backupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := s.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
 }

--- a/dbaas_test.go
+++ b/dbaas_test.go
@@ -20,6 +20,7 @@ const (
 	dbaasClusterID    = "123e4567-e89b-12d3-a456-426614174000"
 	dbaasUserName     = "user_name"
 	dbaasDatabaseName = "user_analytics"
+	testBackupID      = "e13bd88d-79c8-4871-a9c2-a4baca741d0f"
 )
 
 func TestDBaaSServiceOp_ClusterCreate(t *testing.T) {
@@ -423,6 +424,122 @@ func TestDBaaSServiceOp_DbmsList(t *testing.T) {
 	})
 
 	respActual, resp, err := client.DBaaS.DbmsList(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_BackupCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := DBaaSBackupCreateRequest{
+		Name:      "my-backup",
+		ClusterID: dbaasClusterID,
+	}
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	URL := path.Join(DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		reqBody := &DBaaSBackupCreateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.BackupCreate(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_BackupsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedResp := []DBaaSBackup{{ID: testBackupID, Name: "my-backup"}}
+	URL := path.Join(DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.BackupsList(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_BackupGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	backupID := testBackupID
+	expectedResp := &DBaaSBackup{ID: backupID, Name: "my-backup"}
+	URL := path.Join(DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), backupID)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.BackupGet(ctx, backupID, false)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_BackupUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	newName := "new-backup-name"
+	request := DBaaSBackupUpdateRequest{
+		Name: &newName,
+	}
+	backupID := testBackupID
+	expectedResp := &DBaaSBackup{ID: backupID, Name: "new-backup-name"}
+	URL := path.Join(DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), backupID)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		reqBody := &DBaaSBackupUpdateRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.BackupUpdate(ctx, backupID, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
+func TestDBaaSServiceOp_BackupDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	backupID := testBackupID
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	URL := path.Join(DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), backupID)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		resp, _ := json.Marshal(expectedResp)
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.DBaaS.BackupDelete(ctx, backupID)
 	require.NoError(t, err)
 	require.Equal(t, resp.StatusCode, 200)
 	require.Equal(t, respActual, expectedResp)

--- a/util/dbaas.go
+++ b/util/dbaas.go
@@ -11,12 +11,16 @@ import (
 
 const (
 	DBaaSClusterHealthyStatus = "HEALTHY"
+	DBaaSBackupFinishedStatus = "FINISHED"
 	dbaasClusterPollInterval  = 5 * time.Second
+	dbaasBackupPollInterval   = 5 * time.Second
+	dbaasBackupPageSize       = 100
 )
 
 var (
 	ErrDBaaSClustersNotFound = errors.New("no DBaaS clusters were found for the specified search criteria")
 	ErrDBaaSClusterNotReady  = errors.New("DBaaS cluster failed to become healthy within the allocated time")
+	ErrDBaaSBackupNotReady   = errors.New("DBaaS backup failed to become ready within the allocated time")
 )
 
 func CreateDBaaSClusterAndWait(ctx context.Context, client *edgecloud.Client, req edgecloud.DBaaSClusterCreateRequest, timeouts ...time.Duration) (*edgecloud.DBaaSCluster, error) {
@@ -124,4 +128,116 @@ func WaitDBaaSClusterStatusHealthy(ctx context.Context, client *edgecloud.Client
 		case <-ticker.C:
 		}
 	}
+}
+
+func CreateDBaaSBackupAndWait(ctx context.Context, client *edgecloud.Client, req edgecloud.DBaaSBackupCreateRequest, timeouts ...time.Duration) (*edgecloud.DBaaSBackup, error) {
+	ctx, cancel := contextWithTimeout(ctx, timeouts...)
+	defer cancel()
+
+	task, _, err := client.DBaaS.BackupCreate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if task == nil || len(task.Tasks) == 0 {
+		return nil, fmt.Errorf("DBaaS backup create returned no task IDs")
+	}
+
+	backup, err := waitDBaaSBackupByCreatorTaskID(ctx, client, task.Tasks[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return waitDBaaSBackupStatusFinished(ctx, client, backup.ID)
+}
+
+func WaitDBaaSBackupByCreatorTaskID(ctx context.Context, client *edgecloud.Client, creatorTaskID string, timeouts ...time.Duration) (*edgecloud.DBaaSBackup, error) {
+	ctx, cancel := contextWithTimeout(ctx, timeouts...)
+	defer cancel()
+
+	return waitDBaaSBackupByCreatorTaskID(ctx, client, creatorTaskID)
+}
+
+func waitDBaaSBackupByCreatorTaskID(ctx context.Context, client *edgecloud.Client, creatorTaskID string) (*edgecloud.DBaaSBackup, error) {
+	ticker := time.NewTicker(dbaasBackupPollInterval)
+	defer ticker.Stop()
+
+	for {
+		for offset := 0; ; {
+			page, _, err := client.DBaaS.BackupsListPage(ctx, &edgecloud.DBaaSBackupListOptions{
+				Limit:  dbaasBackupPageSize,
+				Offset: offset,
+			})
+			if err != nil {
+				if ctx.Err() != nil {
+					return nil, ErrDBaaSBackupNotReady
+				}
+				return nil, err
+			}
+
+			for i := range page.Results {
+				if page.Results[i].CreatorTaskID == creatorTaskID {
+					return &page.Results[i], nil
+				}
+			}
+
+			if len(page.Results) == 0 || len(page.Results) < dbaasBackupPageSize || (page.Count > 0 && offset+len(page.Results) >= page.Count) {
+				break
+			}
+			offset += len(page.Results)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ErrDBaaSBackupNotReady
+		case <-ticker.C:
+		}
+	}
+}
+
+func WaitDBaaSBackupStatusFinished(ctx context.Context, client *edgecloud.Client, backupID string, timeouts ...time.Duration) (*edgecloud.DBaaSBackup, error) {
+	ctx, cancel := contextWithTimeout(ctx, timeouts...)
+	defer cancel()
+
+	return waitDBaaSBackupStatusFinished(ctx, client, backupID)
+}
+
+func waitDBaaSBackupStatusFinished(ctx context.Context, client *edgecloud.Client, backupID string) (*edgecloud.DBaaSBackup, error) {
+	ticker := time.NewTicker(dbaasBackupPollInterval)
+	defer ticker.Stop()
+
+	for {
+		backup, _, err := client.DBaaS.BackupGet(ctx, backupID, false)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ErrDBaaSBackupNotReady
+			}
+			return nil, err
+		}
+
+		if backup.Status == DBaaSBackupFinishedStatus {
+			return backup, nil
+		}
+
+		if backup.Status == "ERROR" {
+			return nil, fmt.Errorf("DBaaS backup entered ERROR status")
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ErrDBaaSBackupNotReady
+		case <-ticker.C:
+		}
+	}
+}
+
+func contextWithTimeout(ctx context.Context, timeouts ...time.Duration) (context.Context, context.CancelFunc) {
+	if len(timeouts) > 0 {
+		return context.WithTimeout(ctx, timeouts[0])
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, defaultTimeout)
 }

--- a/util/dbaas_test.go
+++ b/util/dbaas_test.go
@@ -291,3 +291,241 @@ func TestCreateDBaaSClusterAndWait_EmptyTaskIDs(t *testing.T) {
 	assert.EqualError(t, err, "DBaaS cluster create returned no task IDs")
 	assert.Nil(t, cluster)
 }
+
+func TestWaitDBaaSBackupStatusFinished(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	backupID := testResourceID
+	getURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), backupID)
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSBackup{
+			ID:     backupID,
+			Status: "FINISHED",
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := WaitDBaaSBackupStatusFinished(context.Background(), client, backupID)
+	assert.NoError(t, err)
+	assert.NotNil(t, backup)
+	assert.Equal(t, backupID, backup.ID)
+}
+
+func TestWaitDBaaSBackupStatusFinished_Error(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	backupID := testResourceID
+	getURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), backupID)
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSBackup{
+			ID:     backupID,
+			Status: "ERROR",
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := WaitDBaaSBackupStatusFinished(context.Background(), client, backupID, 20*time.Millisecond)
+	assert.EqualError(t, err, "DBaaS backup entered ERROR status")
+	assert.Nil(t, backup)
+}
+
+func TestWaitDBaaSBackupStatusFinished_Timeout(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	backupID := testResourceID
+	getURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), backupID)
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSBackup{
+			ID:     backupID,
+			Status: "BUILDING",
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := WaitDBaaSBackupStatusFinished(context.Background(), client, backupID, time.Millisecond)
+	assert.ErrorIs(t, err, ErrDBaaSBackupNotReady)
+	assert.Nil(t, backup)
+}
+
+func TestCreateDBaaSBackupAndWait(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	reqBody := edgecloud.DBaaSBackupCreateRequest{
+		Name:      "my-backup",
+		ClusterID: testResourceID,
+	}
+
+	createURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	getURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID), testResourceID2)
+
+	mux.HandleFunc(createURL, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			got := &edgecloud.DBaaSBackupCreateRequest{}
+			if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			assert.Equal(t, reqBody, *got)
+
+			resp, err := json.Marshal(&edgecloud.TaskResponse{Tasks: []string{testResourceID2}})
+			if err != nil {
+				t.Fatalf("failed to marshal JSON: %v", err)
+			}
+			_, _ = fmt.Fprint(w, string(resp))
+
+			return
+		}
+
+		// GET on createURL = BackupsList
+		backups := []edgecloud.DBaaSBackup{
+			{
+				ID:            testResourceID,
+				CreatorTaskID: testResourceID,
+				Status:        "BUILDING",
+			},
+			{
+				ID:            testResourceID2,
+				CreatorTaskID: testResourceID2,
+				Status:        "BUILDING",
+			},
+		}
+		resp, err := json.Marshal(backups)
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	mux.HandleFunc(getURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.DBaaSBackup{
+			ID:     testResourceID2,
+			Status: "FINISHED",
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := CreateDBaaSBackupAndWait(context.Background(), client, reqBody)
+	assert.NoError(t, err)
+	assert.NotNil(t, backup)
+	assert.Equal(t, testResourceID2, backup.ID)
+	assert.Equal(t, "FINISHED", backup.Status)
+}
+
+func TestCreateDBaaSBackupAndWait_EmptyTaskIDs(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	createURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	mux.HandleFunc(createURL, func(w http.ResponseWriter, r *http.Request) {
+		resp, err := json.Marshal(&edgecloud.TaskResponse{})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := CreateDBaaSBackupAndWait(context.Background(), client, edgecloud.DBaaSBackupCreateRequest{Name: "test"})
+	assert.EqualError(t, err, "DBaaS backup create returned no task IDs")
+	assert.Nil(t, backup)
+}
+
+func TestWaitDBaaSBackupByCreatorTaskID_Timeout(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	listURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	mux.HandleFunc(listURL, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"results":[]}`)
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := WaitDBaaSBackupByCreatorTaskID(context.Background(), client, testResourceID, time.Millisecond)
+	assert.ErrorIs(t, err, ErrDBaaSBackupNotReady)
+	assert.Nil(t, backup)
+}
+
+func TestWaitDBaaSBackupByCreatorTaskID_Found(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	listURL := path.Join(edgecloud.DBaaSBackupsBasePathV3, strconv.Itoa(projectID), strconv.Itoa(regionID))
+	mux.HandleFunc(listURL, func(w http.ResponseWriter, r *http.Request) {
+		backups := []edgecloud.DBaaSBackup{
+			{ID: testResourceID, CreatorTaskID: testResourceID2, Status: "BUILDING"},
+			{ID: testResourceID2, CreatorTaskID: testResourceID, Status: "FINISHED"},
+		}
+		resp, err := json.Marshal(backups)
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		_, _ = fmt.Fprintf(w, `{"results":%s}`, string(resp))
+	})
+
+	client := edgecloud.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL)
+	client.BaseURL = baseURL
+	client.Project = projectID
+	client.Region = regionID
+
+	backup, err := WaitDBaaSBackupByCreatorTaskID(context.Background(), client, testResourceID)
+	assert.NoError(t, err)
+	assert.NotNil(t, backup)
+	assert.Equal(t, testResourceID2, backup.ID)
+}

--- a/util/resource.go
+++ b/util/resource.go
@@ -98,6 +98,13 @@ func DeleteResourceIfExist(ctx context.Context, client *edgecloud.Client, resour
 			return err
 		}
 		return ResourceIsDeleted(ctx, v.Get, resourceID)
+	case edgecloud.DBaaSBackups:
+		if err := deleteAndWait(v.BackupDelete); err != nil {
+			return err
+		}
+		return ResourceIsDeleted(ctx, func(ctx context.Context, id string) (*edgecloud.DBaaSBackup, *edgecloud.Response, error) {
+			return v.BackupGet(ctx, id, false)
+		}, resourceID)
 	default:
 		return errDeleteResourceIfExistIsNotSupported
 	}


### PR DESCRIPTION
Add SDK methods for DBaaS backups CRUD: create, list, get, update, delete.
Includes async wait helpers and unit tests.