### PR TITLE
feat(TF-108)[mkaas]: add ClusterUpgradeVersion method for MKaaS clusters

### DIFF
--- a/mkaas.go
+++ b/mkaas.go
@@ -39,6 +39,7 @@ type MKaaSClusters interface {
 	ClusterGet(context.Context, int) (*MKaaSCluster, *Response, error)
 	ClusterUpdateName(ctx context.Context, clusterID int, reqBody MKaaSClusterUpdateNameRequest) (*TaskResponse, *Response, error)
 	ClusterUpdateMasterNodeCount(ctx context.Context, clusterID int, reqBody MKaaSClusterUpdateMasterNodeCountRequest) (*TaskResponse, *Response, error)
+	ClusterUpgradeVersion(ctx context.Context, clusterID int, reqBody MKaaSClusterUpgradeVersionRequest) (*TaskResponse, *Response, error)
 	ClusterDelete(context.Context, int) (*TaskResponse, *Response, error)
 }
 
@@ -194,6 +195,10 @@ type MKaaSClusterUpdateNameRequest struct {
 
 type MKaaSClusterUpdateMasterNodeCountRequest struct {
 	MasterNodeCount int `json:"master_node_count"`
+}
+
+type MKaaSClusterUpgradeVersionRequest struct {
+	TargetVersion string `json:"target_version"`
 }
 
 // MKaaSCluster represents an EdgecenterCloud MkaaS Cluster.
@@ -425,6 +430,29 @@ func (m *MKaaSServiceOp) ClusterUpdateMasterNodeCount(
 	)
 
 	req, err := m.client.NewRequest(ctx, http.MethodPatch, path, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tasks := new(TaskResponse)
+	resp, err := m.client.Do(ctx, req, tasks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tasks, resp, err
+}
+
+func (m *MKaaSServiceOp) ClusterUpgradeVersion(
+	ctx context.Context, clusterID int, reqBody MKaaSClusterUpgradeVersionRequest,
+) (*TaskResponse, *Response, error) {
+	if resp, err := m.client.Validate(); err != nil {
+		return nil, resp, err
+	}
+
+	path := fmt.Sprintf("%s/%d/upgrade_version", m.client.addProjectRegionPath(MKaaSClustersBasePathV2), clusterID)
+
+	req, err := m.client.NewRequest(ctx, http.MethodPost, path, reqBody)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mkaas_test.go
+++ b/mkaas_test.go
@@ -365,6 +365,43 @@ func TestMKaaSServiceOp_ClusterUpdateMasterNodeCount(t *testing.T) {
 	require.Equal(t, respActual, expectedResp)
 }
 
+func TestMKaaSServiceOp_ClusterUpgradeVersion(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := MKaaSClusterUpgradeVersionRequest{
+		TargetVersion: "v1.32.0",
+	}
+
+	expectedResp := &TaskResponse{Tasks: []string{taskID}}
+	URL := path.Join(
+		MKaaSClustersBasePathV2,
+		strconv.Itoa(projectID),
+		strconv.Itoa(regionID),
+		strconv.Itoa(testResourceIntID),
+		"upgrade_version",
+	)
+
+	mux.HandleFunc(URL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		reqBody := &MKaaSClusterUpgradeVersionRequest{}
+		if err := json.NewDecoder(r.Body).Decode(reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, request, *reqBody)
+		resp, err := json.Marshal(expectedResp)
+		if err != nil {
+			t.Errorf("failed to marshal response: %v", err)
+		}
+		_, _ = fmt.Fprint(w, string(resp))
+	})
+
+	respActual, resp, err := client.MkaaS.ClusterUpgradeVersion(ctx, testResourceIntID, request)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+	require.Equal(t, respActual, expectedResp)
+}
+
 func TestMKaaSServiceOp_PoolUpdateName(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Add ClusterUpgradeVersion method to MKaaSClusters interface and MKaaSServiceOp implementation. Allows upgrading a cluster's Kubernetes version via POST /mkaas/v2/clusters/{project_id}/{region_id}/{cluster_id}/upgrade_version.